### PR TITLE
Add inline editing on admin pages

### DIFF
--- a/budgets/admin.py
+++ b/budgets/admin.py
@@ -1,10 +1,39 @@
 from django.contrib import admin
+from rules.contrib.admin import ObjectPermissionsModelAdmin
+
 from .models import BudgetGroup, Budget, Category, LineItem, OperatingBudget, OperatingLineItem
 
 
+class OperatingLineItemInline(admin.TabularInline):
+    model = OperatingLineItem
+    extra = 3
+
+
+class OperatingBudgetAdmin(ObjectPermissionsModelAdmin):
+    inlines = [OperatingLineItemInline]
+
+
+class LineItemInline(admin.TabularInline):
+    model = LineItem
+    extra = 3
+
+
+class CategoryAdmin(ObjectPermissionsModelAdmin):
+    inlines = [LineItemInline]
+
+
+class CategoryInline(admin.TabularInline):
+    model = Category
+    extra = 1
+
+
+class BudgetAdmin(ObjectPermissionsModelAdmin):
+    inlines = [CategoryInline]
+
+
 admin.site.register(BudgetGroup)
-admin.site.register(Budget)
-admin.site.register(Category)
+admin.site.register(Budget, BudgetAdmin)
+admin.site.register(Category, CategoryAdmin)
 admin.site.register(LineItem)
-admin.site.register(OperatingBudget)
+admin.site.register(OperatingBudget, OperatingBudgetAdmin)
 admin.site.register(OperatingLineItem)

--- a/budgets/models.py
+++ b/budgets/models.py
@@ -1,6 +1,6 @@
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import CharField, PositiveIntegerField, DecimalField, ForeignKey, TextChoices
-from django.contrib.contenttypes.models import ContentType
 
 
 class BudgetGroup(models.Model):
@@ -23,7 +23,7 @@ class Category(models.Model):
     budget = ForeignKey('Budget', on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.name
+        return f"{self.name} ({self.budget.name})"
 
 
 class LineItem(models.Model):

--- a/expenses/admin.py
+++ b/expenses/admin.py
@@ -5,8 +5,13 @@ from rules.contrib.admin import ObjectPermissionsModelAdmin
 from expenses.models import Project, Requisition, Vendor, RequisitionItem, Approval, Payment, PaymentMethod, File
 
 
+class RequisitionItemInline(admin.StackedInline):
+    model = RequisitionItem
+    extra = 1
+
+
 class RequisitionAdmin(ObjectPermissionsModelAdmin):
-    pass
+    inlines = [RequisitionItemInline]
 
 
 admin.site.register(Project)


### PR DESCRIPTION
Changes
----

- Added inline editing to Requisition, Budget, OperatingBudget, Category, LineItem, and OperatingLineItem models
- Cleaned up string representations of budget models to make admin pages more clear