### PR TITLE
Dynamic budget page

### DIFF
--- a/client/src/components/budgets/BudgetCard.tsx
+++ b/client/src/components/budgets/BudgetCard.tsx
@@ -1,0 +1,49 @@
+import { Card, Table } from "antd";
+import React from "react";
+
+import { Category } from "../../generated/types";
+
+interface Props {
+  category: Category;
+}
+
+const BudgetCard: React.FC<Props> = (props) => {
+
+  const lineItemsData = props.category.lineItems.map(item => (
+      {
+        key: item.id,
+        name: item.name,
+        quantity: item.quantity,
+        unitCost: item.unitCost
+      }
+    )
+  ); 
+
+  const lineItemColumns = [
+    {
+      title: "Name",
+      dataIndex: "name",
+      key: "name"
+    },
+    {
+      title: "Quantity",
+      dataIndex: "quantity",
+      key: "quantity"
+    },
+    {
+      title: "Unit Cost",
+      dataIndex: "unitCost",
+      key: "unitCost"
+    },
+  ];
+
+  return (
+  <>
+    <Card title={props.category.name} style={{ width: 300 }}>
+      <Table dataSource={lineItemsData} columns={lineItemColumns} />
+    </Card>
+  </>
+  );
+};
+
+export default BudgetCard;

--- a/client/src/components/budgets/BudgetCard.tsx
+++ b/client/src/components/budgets/BudgetCard.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const BudgetCard: React.FC<Props> = (props) => {
-
+  
   const lineItemsData = props.category.lineItems.map(item => (
       {
         key: item.id,

--- a/client/src/components/budgets/BudgetDetail.tsx
+++ b/client/src/components/budgets/BudgetDetail.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { List, Collapse } from "antd";
+import { useQuery } from "@apollo/client";
+
+import ErrorDisplay from "../../util/ErrorDisplay"
+import BudgetCard from "./BudgetCard";
+import { BUDGET_QUERY } from "../../queries/Budget"
+import { Budget, Category } from "../../generated/types";
+
+const { Panel } = Collapse;
+
+const BudgetDetail: React.FC = () => {
+
+  const { data, loading, error } = useQuery(BUDGET_QUERY);
+
+  if (error) {
+    return <ErrorDisplay error={error} />;
+  }
+
+  const emptyBudget = [
+    {
+      id: 1,
+      name: "loading",
+      categories: [
+        {
+          id: 1,
+          name: "-",
+          lineItems: [
+            {
+              id: 1,
+              name: "-",
+              quantity: 1,
+              unitCost: 1
+            }
+          ], 
+        }
+      ]
+    }
+  ];
+
+  const allBudgets = loading ? emptyBudget : data.budgets;
+
+  return (
+    <>
+      <List
+        dataSource={allBudgets}
+        renderItem={(budget: Budget) => (
+          <Collapse key={budget.id}>
+            <Panel key={budget.id} header={budget.name}>
+                <List
+                  grid={{ gutter: 16, xs: 1, sm: 2, md: 2, lg: 3, xl: 4, xxl: 5 }} 
+                  dataSource={budget.categories}
+                  renderItem={(category: Category) => (
+                  <List.Item>
+                    <BudgetCard key={category.id} category={category} />
+                  </List.Item>
+                  )}
+                />
+            </Panel>
+          </Collapse>
+        )}
+      />
+    </>
+  );
+};
+
+export default BudgetDetail;

--- a/client/src/components/budgets/BudgetDetail.tsx
+++ b/client/src/components/budgets/BudgetDetail.tsx
@@ -1,67 +1,30 @@
 import React from "react";
-import { List, Collapse } from "antd";
-import { useQuery } from "@apollo/client";
+import { List } from "antd";
+import Title from "antd/lib/typography/Title";
 
-import ErrorDisplay from "../../util/ErrorDisplay"
+
 import BudgetCard from "./BudgetCard";
-import { BUDGET_QUERY } from "../../queries/Budget"
 import { Budget, Category } from "../../generated/types";
 
-const { Panel } = Collapse;
+interface Props {
+  budget: Budget;
+}
 
-const BudgetDetail: React.FC = () => {
-
-  const { data, loading, error } = useQuery(BUDGET_QUERY);
-
-  if (error) {
-    return <ErrorDisplay error={error} />;
-  }
-
-  const emptyBudget = [
-    {
-      id: 1,
-      name: "loading",
-      categories: [
-        {
-          id: 1,
-          name: "-",
-          lineItems: [
-            {
-              id: 1,
-              name: "-",
-              quantity: 1,
-              unitCost: 1
-            }
-          ], 
-        }
-      ]
-    }
-  ];
-
-  const allBudgets = loading ? emptyBudget : data.budgets;
-
-  return (
-    <>
-      <List
-        dataSource={allBudgets}
-        renderItem={(budget: Budget) => (
-          <Collapse key={budget.id}>
-            <Panel key={budget.id} header={budget.name}>
-                <List
-                  grid={{ gutter: 16, xs: 1, sm: 2, md: 2, lg: 3, xl: 4, xxl: 5 }} 
-                  dataSource={budget.categories}
-                  renderItem={(category: Category) => (
-                  <List.Item>
-                    <BudgetCard key={category.id} category={category} />
-                  </List.Item>
-                  )}
-                />
-            </Panel>
-          </Collapse>
-        )}
-      />
-    </>
-  );
-};
+const BudgetDetail: React.FC<Props> = (props) => (
+  <>
+    <Title style={{ textAlign: "left" }} level={2}>
+      {props.budget.name} Details
+    </Title>
+    <List
+      grid={{ gutter: 16, xs: 1, sm: 2, md: 2, lg: 3, xl: 4, xxl: 5 }} 
+      dataSource={props.budget.categories}
+      renderItem={(category: Category) => (
+      <List.Item>
+        <BudgetCard key={category.id} category={category} />
+      </List.Item>
+      )}
+    />
+  </>
+);
 
 export default BudgetDetail;

--- a/client/src/components/budgets/Budgets.tsx
+++ b/client/src/components/budgets/Budgets.tsx
@@ -1,15 +1,37 @@
 import React from "react";
-import { Typography } from "antd";
+import { Typography, List } from "antd";
+import { useQuery } from "@apollo/client";
 
-const { Title, Text } = Typography;
+import BudgetCard from "./BudgetCard";
+import { BUDGET_QUERY } from "../../queries/Budget"
 
-const Budgets: React.FC = () => (
-  <>
-    <Title style={{ textAlign: "left" }} level={2}>
-      Your Budgets
-    </Title>
-    <Text>Development currently in progress...</Text>
-  </>
-);
+const { Title } = Typography;
+
+const Budgets: React.FC = () => {
+
+  const { data } = useQuery(BUDGET_QUERY);
+  console.log(data);
+
+  
+  const budgetCardCategories = data.budgets.categories;
+
+  return (
+    <>
+      <Title style={{ textAlign: "left" }} level={2}>
+        Your Budgets
+      </Title>
+
+      <List
+        grid={{ gutter: 16, xs: 1, sm: 2, md: 2, lg: 3, xl: 4, xxl: 5 }} 
+        dataSource={budgetCardCategories}
+        renderItem={category => (
+          <List.Item>
+            <BudgetCard key={category.id} category={category} />
+          </List.Item>
+        )}
+      />
+    </>
+  );
+};
 
 export default Budgets;


### PR DESCRIPTION
Changes
----


- Added dynamic rendering of budgets from the database using the GraphQL queries. 
- Did this by creating BudgetCard component that renders the details of each budget category. 
- On the Budgets page, places each budget into its own Collapse. Once you open up the Collapse, it contains cards of each of the categories.

- **The Budgets.tsx file in this commit was for my testing only. Use the Budgets home page from #242 and then use the BudgetDetail.tsx component accordingly**

Screenshots
----
![Screen Shot 2021-04-07 at 12 44 02 AM](https://user-images.githubusercontent.com/22090159/113830383-6c411000-973b-11eb-9477-5ac475c6d620.png)
![Screen Shot 2021-04-07 at 12 44 07 AM](https://user-images.githubusercontent.com/22090159/113830392-6e0ad380-973b-11eb-8fb0-31802e9c57a8.png)
- Places each budget into its own Collapse. Once you open up the Collapse, it contains cards of each of the categories.

Resolved issues
-----

Closes # 240